### PR TITLE
Configuration file name can be set

### DIFF
--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -20,4 +20,4 @@ sources:
 - https://github.com/kubernetes/charts
 - https://github.com/kuberstack/bitcoind
 - https://github.com/kylemanna/docker-bitcoind
-version: 0.1.4
+version: 0.2

--- a/charts/bitcoind/templates/deployment.yaml
+++ b/charts/bitcoind/templates/deployment.yaml
@@ -24,12 +24,12 @@ spec:
       initContainers:
         - name: copy-bitcoind-config
           image: busybox
-          command: ['sh', '-c', "cp /configmap/bitcoin.conf {{ .Values.path }}/.bitcoin/bitcoin.conf"]
+          command: ['sh', '-c', "cp /configmap/{{ .Values.configurationFilename}} {{ .Values.path }}/{{ .Values.subPath}}/{{ .Values.configurationFilename}}"]
           volumeMounts:
             - name: configmap
               mountPath: /configmap
             - name: config
-              mountPath: "{{ .Values.path }}/.bitcoin/"
+              mountPath: "{{ .Values.path }}/{{ .Values.subPath }}/"
       {{- end }}
       containers:
         - name: {{ template "bitcoind.fullname" . }}
@@ -52,11 +52,11 @@ spec:
               containerPort: {{ .Values.service.testnetP2pPort }}
           volumeMounts:
             - name: data
-              mountPath: {{ .Values.dataPath }}
+              mountPath: {{ .Values.path }}
             {{- if .Values.configurationFile }}
             - name: config
-              mountPath: "{{ .Values.path }}/.bitcoin/bitcoin.conf"
-              subPath: bitcoin.conf
+              mountPath: "{{ .Values.path }}/{{ .Values.subPath }}/{{ .Values.configurationFilename }}"
+              subPath: {{ .Values.configurationFilename }}
             {{- end }}
       volumes:
         {{- if .Values.configurationFile }}

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -40,7 +40,8 @@ resources: {}
 #   value: SOME_VALUE
 
 path: /home/bitcoin
-dataPath: /data
+subPath: .bitcoin
+configurationFilename: bitcoin.conf
 
 # Custom bitcoind configuration file used to override default bitcoind settings
 configurationFile:


### PR DESCRIPTION
This give us the ability to set subpath and name of the configuration
file, usable for cases when in docker image the config filename is
hardcoded. For example: /home/litecoin/.litecoin/litecoin.conf in many
of the litecoin images.