### PR TITLE
 Add multi-volume persistence support with legacy fallback for simple-node chart

### DIFF
--- a/charts/simple-node/Chart.yaml
+++ b/charts/simple-node/Chart.yaml
@@ -9,4 +9,4 @@ keywords:
 maintainers:
 - name: Ivan Genev
 name: simple-node
-version: 0.0.3
+version: 0.1.0

--- a/charts/simple-node/README.md
+++ b/charts/simple-node/README.md
@@ -1,4 +1,3 @@
-
 # simple-node Helm Chart
 
 A Helm chart to deploy a simple-node using a Kubernetes StatefulSet. Supports configuration via ConfigMap, persistence, multiple service ports, sidecars, and ingress.
@@ -8,6 +7,9 @@ A Helm chart to deploy a simple-node using a Kubernetes StatefulSet. Supports co
 ## Features
 
 - Deploys simple-node as a StatefulSet with persistent storage
+- **Supports two persistence configuration methods:**
+  - Legacy single-volume syntax
+  - New multi-volume syntax
 - Configurable via Helm values including custom config files
 - Supports mounting config files with subPath
 - Multi-port service configuration (HTTP, RPC, WebSocket)
@@ -47,24 +49,29 @@ helm install simple-node ./simple-node -f myvalues.yaml
 
 The following table lists the main configurable parameters and their default values:
 
-| Parameter              | Description                                  | Default                       |
-|------------------------|----------------------------------------------|-------------------------------|
-| `image.repository`     | Docker image repository                      | `helo-world`             |
-| `image.tag`            | Docker image tag                             | `latest`                      |
-| `image.pullPolicy`     | Image pull policy                            | `IfNotPresent`                |
-| `appNameOverride`      | Override app name used in labels             | `simple-node`                     |
-| `replicas`             | Number of pod replicas                       | `1`                           |
-| `persistence.enabled`  | Enable persistent storage                    | `true`                        |
-| `persistence.size`     | Persistent volume size                        | `10Gi`                       |
-| `config.enabled`       | Enable ConfigMap mount                        | `true`                       |
-| `config.data`          | Configuration file contents                   | See `simple-node.conf` example   |
-| `service.type`         | Kubernetes service type                       | `ClusterIP`                  |
-| `service.ports`        | List of service ports                         |  RPC(8332)                   |
-| `resources.requests`   | Pod resource requests                         | CPU: `2`, Memory: `4Gi`     |
-| `command`              | Container command override                    | `[]`                         |
-| `args`                 | Container args override                       | `[]`                         |
-| `ingress.enabled`      | Enable ingress                               | `false`                       |
-| `ingress.host`         | Ingress host                                 | `simple-node.example.com`            |
+| Parameter                   | Description                                                                      | Default                       |
+|-----------------------------|----------------------------------------------------------------------------------|-------------------------------|
+| `image.repository`          | Docker image repository                                                          | `hello-world`                 |
+| `image.tag`                 | Docker image tag                                                                 | `latest`                      |
+| `image.pullPolicy`          | Image pull policy                                                                | `IfNotPresent`                |
+| `appNameOverride`           | Override app name used in labels                                                 | `simple-node`                 |
+| `replicas`                  | Number of pod replicas                                                           | `1`                           |
+| `persistence.enabled`       | Enable persistent storage                                                        | `true`                        |
+| `persistence.volumes`       | **New:** List of persistence volume definitions (multi-volume syntax)            | `[]`                          |
+| `persistence.VolumeName`    | **Legacy:** Name of the persistent volume (single-volume syntax)                  | `data`                        |
+| `persistence.mountPath`     | **Legacy:** Mount path for the persistent volume                                  | `/data`                       |
+| `persistence.size`          | **Legacy:** Persistent volume size                                                | `10Gi`                        |
+| `persistence.accessMode`    | **Legacy:** Access mode for the persistent volume                                 | `ReadWriteOnce`               |
+| `persistence.storageClass`  | **Legacy:** Storage class for the persistent volume                               | *(empty)*                     |
+| `config.enabled`            | Enable ConfigMap mount                                                            | `true`                        |
+| `config.data`               | Configuration file contents                                                       | See `simple-node.conf` example|
+| `service.type`              | Kubernetes service type                                                           | `ClusterIP`                   |
+| `service.ports`             | List of service ports                                                             | RPC(8332)                     |
+| `resources.requests`        | Pod resource requests                                                             | CPU: `2`, Memory: `4Gi`        |
+| `command`                   | Container command override                                                        | `[]`                          |
+| `args`                      | Container args override                                                           | `[]`                          |
+| `ingress.enabled`           | Enable ingress                                                                    | `false`                       |
+| `ingress.host`              | Ingress host                                                                      | `simple-node.example.com`     |
 
 For full configurable options, see [values.yaml](./values.yaml).
 
@@ -84,15 +91,50 @@ config:
     printtoconsole=1
 ```
 
+---
+
 ### Persistence
 
-Ensure your Kubernetes cluster has a default StorageClass or specify one in `persistence.storageClass`.
+You can configure persistence **in two ways**:
+
+#### 1. **New (Recommended) Multi-Volume Syntax**
+Allows multiple volumes with separate mount paths and settings.
+
+```yaml
+persistence:
+  enabled: true
+  volumes:
+    - name: uploads
+      mountPath: /app/apps/httpServer/uploads
+      size: 30Gi
+      storageClass: openebs-hostpath
+    - name: logs
+      mountPath: /logs
+      size: 50Gi
+      storageClass: openebs-hostpath
+```
+
+#### 2. **Legacy Single-Volume Syntax**
+Supported for backward compatibility.
+
+```yaml
+persistence:
+  enabled: true
+  VolumeName: data
+  mountPath: /data
+  size: 10Gi
+  accessMode: ReadWriteOnce
+  storageClass: gp2
+```
+
+If both `persistence.volumes` and the legacy keys are set,
+**`persistence.volumes` takes precedence**.
 
 ---
 
 ## Notes
 
-- The chart creates a StatefulSet with a PersistentVolumeClaim for blockchain data storage.
+- The chart creates a StatefulSet with one or more PersistentVolumeClaims depending on the persistence configuration used.
 - ConfigMap mounts your `simple-node.conf` using `subPath` to keep the config file intact.
 - If you want to run with pruned mode or other simple-node Core flags, use the `command` and `args` parameters.
 
@@ -101,5 +143,3 @@ Ensure your Kubernetes cluster has a default StorageClass or specify one in `per
 ## License
 
 This project is licensed under the MIT License.
-
----

--- a/charts/simple-node/templates/statefulset.yaml
+++ b/charts/simple-node/templates/statefulset.yaml
@@ -1,3 +1,16 @@
+{{- /* Support both: new persistence.volumes[] and legacy flat keys */ -}}
+{{- $pvols := .Values.persistence.volumes | default (list) -}}
+{{- if and .Values.persistence.enabled (empty $pvols) -}}
+  {{- $legacy := dict
+        "name"         (default "data" .Values.persistence.VolumeName)
+        "mountPath"    (default "/data" .Values.persistence.mountPath)
+        "size"         .Values.persistence.size
+        "accessModes"  (list (default "ReadWriteOnce" .Values.persistence.accessMode))
+        "storageClass"  .Values.persistence.storageClass
+      -}}
+  {{- $pvols = append $pvols $legacy -}}
+{{- end -}}
+
 apiVersion: {{ template "simple-node.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
@@ -31,24 +44,36 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "simple-node.serviceAccountName" . | quote }}
       {{- if .Values.podSecurityContext }}
-      securityContext: 
+      securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
+
       {{- if and .Values.config.enabled (eq .Values.config.mode "copy") }}
       initContainers:
         - name: copy-config
           image: busybox
-          command: ["sh", "-c", "cp {{ .Values.config.mountPath }} {{ .Values.config.targetPath }}"]
+          command:
+            - sh
+            - -c
+            - >
+              mkdir -p $(dirname {{ .Values.config.targetPath }}) &&
+              cp -f {{ .Values.config.mountPath | default "/tmp/bitcoin.conf" }} {{ .Values.config.targetPath }}
           volumeMounts:
-            {{- if .Values.persistence.enabled }}
-            - name: data
-              mountPath: {{ .Values.persistence.mountPath | default "/data" }}
+            {{- if and .Values.persistence.enabled $pvols }}
+            {{- range $v := $pvols }}
+            - name: {{ $v.name }}
+              mountPath: {{ $v.mountPath }}
+              {{- if $v.subPath }}
+              subPath: {{ $v.subPath }}
+              {{- end }}
+            {{- end }}
             {{- end }}
             - name: config
               mountPath: {{ .Values.config.mountPath | default "/tmp/bitcoin.conf" }}
               subPath: config
               readOnly: true
       {{- end }}
+
       containers:
         {{- if .Values.sidecarContainers }}
         {{- toYaml .Values.sidecarContainers | nindent 8 }}
@@ -58,11 +83,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.command }}
           command:
-            {{- toYaml .Values.command | nindent 12 }}
+{{ toYaml .Values.command | indent 12 }}
           {{- end }}
           {{- if .Values.args }}
           args:
-            {{- toYaml .Values.args | nindent 12 }}
+{{ toYaml .Values.args | indent 12 }}
           {{- end }}
           {{- if .Values.environment }}
           env:
@@ -72,7 +97,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- if .Values.containerSecurityContext }}
-          securityContext: 
+          securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           ports:
@@ -82,8 +107,9 @@ spec:
               protocol: {{ .protocol | default "TCP" }}
           {{- end }}
           {{- if .Values.containerPorts }}
-            {{- toYaml .Values.containerPorts | nindent 12 }}
+{{ toYaml .Values.containerPorts | indent 12 }}
           {{- end }}
+
           {{- with .Values.probes.livenessProbe }}
           livenessProbe:
 {{ toYaml . | indent 12 }}
@@ -92,55 +118,94 @@ spec:
           readinessProbe:
 {{ toYaml . | indent 12 }}
           {{- end }}
-
           {{- with .Values.probes.startupProbe }}
           startupProbe:
 {{ toYaml . | indent 12 }}
           {{- end }}
+
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+
           {{- if or .Values.persistence.enabled .Values.config.enabled }}
           volumeMounts:
-            {{- if .Values.persistence.enabled }}
-            - name: {{ .Values.persistence.VolumeName | default "data" }}
-              mountPath: {{ .Values.persistence.mountPath | default "/data" }}
+            {{- if and .Values.persistence.enabled $pvols }}
+            {{- range $v := $pvols }}
+            - name: {{ $v.name }}
+              mountPath: {{ $v.mountPath }}
+              {{- if $v.subPath }}
+              subPath: {{ $v.subPath }}
+              {{- end }}
+              {{- if $v.readOnly }}
+              readOnly: true
+              {{- end }}
+            {{- end }}
             {{- end }}
             {{- if and .Values.config.enabled (eq .Values.config.mode "mount") }}
             - name: config
               mountPath: {{ .Values.config.mountPath }}
               subPath: config
               readOnly: true
-            {{- end }}            
+            {{- end }}
           {{- end }}
-    {{- if .Values.config.enabled }}
+
+      {{- if or .Values.config.enabled (and .Values.persistence.enabled $pvols) }}
       volumes:
+        {{- if .Values.config.enabled }}
         - name: config
           configMap:
             name: {{ template "simple-node.confname" . }}
             defaultMode: 0600
-    {{- end }}
-    {{- with .Values.nodeSelector }}
+        {{- end }}
+        {{- if and .Values.persistence.enabled $pvols }}
+        {{- range $v := $pvols }}
+        {{- if $v.existingClaim }}
+        - name: {{ $v.name }}
+          persistentVolumeClaim:
+            claimName: {{ $v.existingClaim }}
+        {{- else if $v.emptyDir }}
+        - name: {{ $v.name }}
+          emptyDir: {{- toYaml $v.emptyDir | nindent 12 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+
+      {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-  {{- if .Values.persistence.enabled }}
+      {{- end }}
+
+  {{- if and .Values.persistence.enabled $pvols }}
   volumeClaimTemplates:
+    {{- range $v := $pvols }}
+    {{- if and (not $v.existingClaim) (not $v.emptyDir) }}
     - metadata:
-        name: {{ .Values.persistence.VolumeName | default "data" }}
+        name: {{ $v.name }}
+        {{- with $v.annotations }}
+        annotations:
+{{ toYaml . | indent 10 }}
+        {{- end }}
       spec:
-        accessModes: [ {{ $.Values.persistence.accessMode | quote }} ]
-        {{- if $.Values.persistence.storageClass }}
-        storageClassName: {{ $.Values.persistence.storageClass }}
+        accessModes:
+          {{- if $v.accessModes }}
+{{ toYaml $v.accessModes | indent 10 }}
+          {{- else }}
+          - ReadWriteOnce
+          {{- end }}
+        {{- if $v.storageClass }}
+        storageClassName: {{ $v.storageClass }}
         {{- end }}
         resources:
           requests:
-            storage: {{ $.Values.persistence.size }}
-  {{- end }} 
+            storage: {{ required (printf "persistence.volumes[%s].size is required for PVC creation" $v.name) $v.size }}
+    {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/simple-node/values.yaml
+++ b/charts/simple-node/values.yaml
@@ -51,11 +51,26 @@ resources:
 # Persistence configuration
 persistence:
   enabled: false
-  mountPath: "/data"
-  storageClass: ""
-  VolumeName: ""
-  accessMode: ReadWriteOnce
+
+  ## --- New multi-volume syntax (preferred) ---
+  ## Define one or more volumes here. Each volume can:
+  ## - create a new PVC by specifying `size` (and optional storageClass, accessMode)
+  ## - use an existing PVC by specifying `existingClaim`
+  ## - use an emptyDir by specifying `emptyDir: {}`
+  volumes:
+    - name: data
+      mountPath: /data
+      storageClass: ""
+      accessMode: ReadWriteOnce
+      size: 10Gi
+
+  ## --- Legacy single-volume syntax (for backward compatibility) ---
+  ## Used only if `persistence.volumes` is empty
+  VolumeName: data
+  mountPath: /data
   size: 10Gi
+  accessMode: ReadWriteOnce
+  storageClass: ""
 
 # Service configuration and ports
 service:
@@ -65,7 +80,7 @@ service:
       port: 8332
       targetPort: 8332
 
-# Container ports configuration 
+# Container ports configuration
 containerPorts: {}
 
 # Sidecar containers (empty by default)


### PR DESCRIPTION
This PR updates the Helm chart to support **multiple persistent volumes** while maintaining backward compatibility with the existing single-volume configuration.

**Changes:**

* Added `persistence.volumes[]` for defining multiple PVCs, existing PVCs, or `emptyDir` mounts.
* Retained legacy `persistence.VolumeName`, `persistence.mountPath`, `persistence.size`, etc., as a fallback when `persistence.volumes` is empty.
* Updated StatefulSet template to:

  * Loop over `persistence.volumes` for mounts, `volumes:`, and `volumeClaimTemplates`.
  * Fallback to single-volume values if `volumes[]` is empty.
* Updated default `values.yaml` with both new and legacy persistence configurations.
* Updated README with documentation for both persistence methods and precedence rules.

**Usage Notes:**

* **Recommended:** Use `persistence.volumes[]` for new deployments.
* **Legacy Support:** Single-volume keys still work if `persistence.volumes` is not set.
* If both formats are configured, `persistence.volumes` takes precedence.
