### PR TITLE
Allows to have secret refs in simple-node

### DIFF
--- a/charts/simple-node/templates/statefulset.yaml
+++ b/charts/simple-node/templates/statefulset.yaml
@@ -91,10 +91,17 @@ spec:
           {{- end }}
           {{- if .Values.environment }}
           env:
-            {{- range $key, $val := .Values.environment }}
-            - name: {{ $key }}
-              value: {{ $val | quote }}
-            {{- end }}
+          {{- range $name, $v := .Values.environment }}
+            - name: {{ $name }}
+              {{- if kindIs "map" $v }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required (printf "environment.%s.secretName is required" $name) $v.secretName }}
+                  key:  {{ required (printf "environment.%s.key is required" $name) $v.key }}
+              {{- else }}
+              value: {{ $v | quote }}
+              {{- end }}
+          {{- end }}
           {{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext:


### PR DESCRIPTION
Under environment key we can have secrets refs in the following format:

```yaml
environment:
  PLAIN_VAR: "hello"
  DB_USER:
    secretName: app-secrets
    key: dbUser
  DB_PASS:
    secretName: app-secrets
    key: dbPass
```