### PR TITLE
Add extra volume and volume mount configurations to simple-node chart

### DIFF
--- a/charts/simple-node/Chart.yaml
+++ b/charts/simple-node/Chart.yaml
@@ -9,4 +9,4 @@ keywords:
 maintainers:
 - name: Ivan Genev
 name: simple-node
-version: 0.2.0
+version: 0.2.1

--- a/charts/simple-node/templates/statefulset.yaml
+++ b/charts/simple-node/templates/statefulset.yaml
@@ -133,7 +133,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 
-          {{- if or .Values.persistence.enabled .Values.config.enabled }}
+          {{- if or .Values.persistence.enabled .Values.config.enabled .Values.extraVolumeMounts }}
           volumeMounts:
             {{- if and .Values.persistence.enabled $pvols }}
             {{- range $v := $pvols }}
@@ -153,9 +153,12 @@ spec:
               subPath: config
               readOnly: true
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           {{- end }}
 
-      {{- if or .Values.config.enabled (and .Values.persistence.enabled $pvols) }}
+      {{- if or .Values.config.enabled (and .Values.persistence.enabled $pvols) .Values.extraVolumes }}
       volumes:
         {{- if .Values.config.enabled }}
         - name: config
@@ -175,8 +178,14 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- end }}
 
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/simple-node/values.yaml
+++ b/charts/simple-node/values.yaml
@@ -86,6 +86,15 @@ containerPorts: {}
 # Sidecar containers (empty by default)
 sidecarContainers: {}
 
+# Extra volumes to add to the pod
+extraVolumes: []
+
+# Extra volume mounts to add to the main container
+extraVolumeMounts: []
+
+# Termination grace period in seconds
+terminationGracePeriodSeconds: null
+
 # Kubernetes scheduling settings
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Summary
This pull request updates the simple-node Helm chart to include enhanced volume configuration options. It introduces the capability to define extra volumes and volume mounts through new parameters in the `values.yaml` file. This feature enhances the flexibility of the chart for users who require additional storage resources within their deployments.

## Volume configuration changes
| File                          | Changes                              |
|-------------------------------|--------------------------------------|
| `charts/simple-node/Chart.yaml` | Updated version to 0.2.1            |
| `charts/simple-node/values.yaml` | Added `extraVolumes` and `extraVolumeMounts` parameters |
| `charts/simple-node/templates/statefulset.yaml` | Modified StatefulSet template to include extra mount and volume configurations based on new values |

## Other changes
- Increased version number in `Chart.yaml` to 0.2.1
- Enhanced logic in `statefulset.yaml` to conditionally include extra volumes and mounts
- Added description for new parameters in `values.yaml`

## Test plan
- [x] Deploy the updated Helm chart with new `extraVolumes` and `extraVolumeMounts` parameters
- [x] Verify that volumes are created correctly in the Kubernetes pod
- [x] Check that the volume mounts are correctly applied to the main container